### PR TITLE
Un-deprecate `<LayoutProvider>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,21 @@ Then, we'll revist our Next.js page to inject our data:
 
 Should you need to fetch additional data for your page, you can define a page-specific `getStaticProps` or `getServerSideProps` function, then pass it to `wrapGetStaticProps` or `wrapGetServerSideProps`, respectively.
 
+### (Optional) Connecting `next-super-layout` to your Next.js `_app`
+
+To ensure that layout-specific state is persisted between route changes, we can choose to define a custom Next.js `_app` component onto which we'll connect our layout-wrapped pages. Take a look:
+
+```tsx
+// pages/_app
+import { LayoutProvider } from 'next-super-layout';
+
+export default function App(props) {
+  return <LayoutProvider {...props} />;
+}
+```
+
+_Voila!_
+
 ### Composing layouts
 
 With `next-super-layout`, it's effortless to compose multiple layouts together using the `combineLayouts` function:

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { GetServerSideProps, GetStaticProps, GetStaticPropsContext } from 'next';
+import type { GetServerSideProps, GetStaticProps, GetStaticPropsContext, NextPage } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
 import type { ComponentType } from 'react';
 
@@ -37,14 +37,6 @@ export type DataLayout = {
 
 export type LayoutData<T extends Layout<any>> = T extends Layout<infer R> ? R : never;
 
-// --- DEPRECATED ----------------------------------------------------------- //
-
-// TODO: remove these in v4
-
-/** @deprecated */
-export type PageWithLayout<Props = any> = ComponentType<Props> & {
-  ['__next_super_layout:getLayout']?: (node: JSX.Element) => JSX.Element;
+export type PageWithLayout<Props = any> = NextPage<Props> & {
+  ['__next_super_layout:getLayout']?: (Component: NextPage<Props>, pageProps: Props) => JSX.Element;
 };
-
-/** @deprecated */
-export type WrappedPage<Props = any> = ComponentType<Props> & { getLayout?: GetLayoutFn<any> };


### PR DESCRIPTION
Turns out there is a use-case for `<LayoutProvider>` after all: to persist component state within layouts between route changes.

This PR supports usage with and without `<LayoutProvider>` automatically.