### PR TITLE
Better compat with rules of hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ export const myLayout = createLayout({
 });
 ```
 
+> **NOTE** If you encounter a message from ESLint about "rules of hooks" violations because `"React component names must start with an uppercase letter"`, you can resolve this by changing `getLayout` to `GetLayout` (note the capitalization).
+
 Once we've created our layout, we'll connect it to a Next.js page using `createPageWrapper`:
 
 ```tsx
@@ -91,6 +93,8 @@ Then, we'll revist our Next.js page to inject our data:
 ```
 
 Should you need to fetch additional data for your page, you can define a page-specific `getStaticProps` or `getServerSideProps` function, then pass it to `wrapGetStaticProps` or `wrapGetServerSideProps`, respectively.
+
+> **NOTE** `wrapGetStaticProps` and `wrapGetServerSideProps` are available as a shorthand with `gSP` and `gSSP`, respectively.
 
 ### (Optional) Connecting `next-super-layout` to your Next.js `_app`
 

--- a/src/layout.tsx
+++ b/src/layout.tsx
@@ -152,9 +152,10 @@ export function createPageWrapper<T extends Array<Layout<any>>>(...layouts: T): 
       const isWithinLayoutProvider = useContext(LayoutProviderContext);
       const pagesCombined = layouts.reduceRight(
         (element, l) => {
-          const { name, getLayout } = getLayoutMeta(l);
+          const { name, getLayout, GetLayout } = getLayoutMeta(l);
           const layoutProps = props[getLayoutKey(name)];
-          return getLayout ? getLayout(element, layoutProps) : element;
+          const getLayoutResolved = getLayout || GetLayout;
+          return getLayoutResolved ? getLayoutResolved(element, layoutProps) : element;
         },
         isWithinLayoutProvider ? <Component {...props} /> : <Page {...props} />,
       );
@@ -205,8 +206,13 @@ export function createDataWrapper<T extends Array<DataLayout>>(...fetchers: T) {
   };
 
   return {
+    // `getStaticProps` wrappers
     wrapGetStaticProps: getPropsWrapper as GetStaticPropsWrapper,
+    gSP: getPropsWrapper as GetStaticPropsWrapper, // shorthand for `wrapGetStaticProps`
+
+    // `getServerSideProps` wrappers
     wrapGetServerSideProps: getPropsWrapper as GetServerSidePropsWrapper,
+    gSSP: getPropsWrapper as GetServerSidePropsWrapper, // shorthand for `wrapGetServerSideProps`
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,8 +21,24 @@ export type GetServerSidePropsWrapper = <
 ) => GetServerSideProps<P, Q>;
 
 export interface CreateLayoutOptions<Data> {
+  /**
+   * A unique key identifying this layout for a NextJS page.
+   */
   name: string;
+
+  /**
+   * Returns a React element wrapping a NextJS page with arbitrary UI.
+   */
   getLayout?: GetLayoutFn<Data>;
+
+  /**
+   * Returns a React element wrapping a NextJS page with arbitrary UI.
+   *
+   * @alias for `getLayout`
+   *
+   * NOTE: `getLayout` takes precedence over `GetLayout`.
+   */
+  GetLayout?: GetLayoutFn<Data>;
 }
 
 export type Layout<Data = any> = {


### PR DESCRIPTION
- Offers an escape hatch to silence ESLint warnings about `"React component names must start with an uppercase letter."` by accepting a `GetLayout` option as an alias to `getLayout`.
- Adds `gSP` and `gSSP` as shorthands for `wrapGetStaticProps` and `wrapGetServerSideProps`, respectively.